### PR TITLE
Make $ref from external source usable

### DIFF
--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -82,6 +82,13 @@ func TestValidate(t *testing.T) {
 # @schema`,
 			expectedValid: true,
 		},
+		{
+			comment: `
+# @schema
+# $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.29.2/affinity-v1.json
+# @schema`,
+			expectedValid: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
JSON Schema supports the keyword `$ref` for specifying an external schema for a key.

This PR adds the http loader from the `santhosh-tekuri/jsonschema` project and disables generation and validation of other fields once `$ref` has been specified.