### PR TITLE
Add flag to disable default additionalProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Flags:
   -s, --keep-full-comment             Keep the whole leading comment (default: cut at empty line)
   -l, --log-level string              Level of logs that should printed, one of (panic, fatal, error, warning, info, debug, trace) (default "info")
   -n, --no-dependencies               don't analyze dependencies
+  -a, --omit-additional-properties    do not set "additionalProperties": false by default
   -o, --output-file string            jsonschema file path relative to each chart directory to which jsonschema will be written (default "values.schema.json")
   -f, --value-files strings           filenames to check for chart values (default [values.yaml])
   -v, --version                       version for helm-schema

--- a/cmd/helm-schema/cli.go
+++ b/cmd/helm-schema/cli.go
@@ -61,6 +61,8 @@ func newCommand(run func(cmd *cobra.Command, args []string) error) (*cobra.Comma
 		StringSliceP("value-files", "f", []string{"values.yaml"}, "filenames to check for chart values")
 	cmd.PersistentFlags().
 		StringP("output-file", "o", "values.schema.json", "jsonschema file path relative to each chart directory to which jsonschema will be written")
+	cmd.PersistentFlags().
+		BoolP("omit-additional-properties", "a", false, "do not set \"additionalProperties\": false by default")
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("HELM_SCHEMA")

--- a/cmd/helm-schema/main.go
+++ b/cmd/helm-schema/main.go
@@ -48,6 +48,7 @@ type Result struct {
 
 func worker(
 	dryRun, keepFullComment, dontRemoveHelmDocsPrefix bool,
+	omitAdditionalProperties bool,
 	valueFileNames []string,
 	outFile string,
 	queue <-chan string,
@@ -120,7 +121,7 @@ func worker(
 			continue
 		}
 
-		result.Schema = schema.YamlToSchema(&values, keepFullComment, dontRemoveHelmDocsPrefix, nil)
+		result.Schema = schema.YamlToSchema(&values, keepFullComment, dontRemoveHelmDocsPrefix, omitAdditionalProperties, nil)
 
 		results <- result
 	}
@@ -136,6 +137,7 @@ func exec(cmd *cobra.Command, _ []string) error {
 	outFile := viper.GetString("output-file")
 	valueFileNames := viper.GetStringSlice("value-files")
 	dontRemoveHelmDocsPrefix := viper.GetBool("dont-strip-helm-docs-prefix")
+	omitAdditionalProperties := viper.GetBool("omit-additional-properties")
 	workersCount := runtime.NumCPU() * 2
 
 	// 1. Start a producer that searches Chart.yaml and values.yaml files
@@ -163,6 +165,7 @@ func exec(cmd *cobra.Command, _ []string) error {
 				dryRun,
 				keepFullComment,
 				dontRemoveHelmDocsPrefix,
+				omitAdditionalProperties,
 				valueFileNames,
 				outFile,
 				queue,


### PR DESCRIPTION
This PR adds a new flag which allows users to disable the default `"additionalProperties": false` included for all objects that omit this field in its schema annotation.