### PR TITLE
Print error on command execution

### DIFF
--- a/cmd/helm-schema/main.go
+++ b/cmd/helm-schema/main.go
@@ -339,6 +339,7 @@ func main() {
 	}
 
 	if err := command.Execute(); err != nil {
+		log.Errorf("Execution error: %s", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This PR prints the error thrown by `command.Execute()`