### PR TITLE
doc: add annotation examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-values.yaml
-values.schema.json
+./values.yaml
+./values.schema.json
 
 dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,14 @@ repos:
     rev: 0.10.0
     hooks:
       - id: helm-schema
+        # for all available options: helm-schema -h
+        args:
+          # directory to search recursively within for charts
+          - "--chart-search-root=."
+
+          # don't analyze dependencies
+          - "--no-dependencies"
+
+          # list of fields to skip from being created by default
+          # e.g. generate a relatively permissive schema
+          # - "--skip-auto-generation=required,additionalProperties"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The first files found will be read and a jsonschema will be created.
 For every dependency defined in the `Chart.yaml` file, a reference to the dependencies JSON schema
 will be created.
 
-ℹ️ The tool uses `jsonschema` Draft 7, because the library helm uses only supports that version.
+> [!NOTE]
+> The tool uses `jsonschema` Draft 7, because the library helm uses only supports that version.
 
 ## Installation
 
@@ -80,46 +81,52 @@ Flags:
 
 ## Annotations
 
-The `jsonschema` must be between two entries of : `# @schema`, example below :
+The `jsonschema` must be between two entries of `# @schema` :
 
 ```yaml
 # @schema
 # my: annotation
 # @schema
+# you can add comment here as well
+foo: bar
 ```
 
-⚠️ It must be written in front of the key you want to annotate.
+> [!WARNING]
+> It must be written just above the key you want to annotate.
 
-ℹ️ If you don't use the `properties` option on hashes or don't use `items` on arrays, it will be parsed from the values and their annotations instead.
+> [!NOTE]
+> If you don't use the `properties` option on hashes/objects or don't use `items` on arrays, it will be parsed from the values and their annotations instead.
 
 ### Available annotations
 
-| Key                    | Description                                                                                                                                                                                          | Values                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `type`                 | Defines the [jsonschema-type](https://json-schema.org/understanding-json-schema/reference/type.html) of the object. Multiple values are suported (e.g. `[string, integer]`) as a shortcut to `anyOf` | `object`, `array`, `string`, `number`, `integer`, `boolean` or `null`               |
-| `title`                | Defines the [title field](https://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title) of the object                                                                    | Defaults to the key itself                                                          |
-| `description`          | Defines the [description field](https://json-schema.org/understanding-json-schema/reference/generic.html?highlight=description) of the object.                                                       | Defaults to the comment which has no `# @schema` prefix                             |
-| `default`              | Sets the default value and will be displayed first on the users IDE                                                                                                                                  |                                                                                     |
-| `properties`           | Contains a map with keys as property names and values as schema                                                                                                                                      | Takes an `object`                                                                   |
-| `pattern`              | Regex pattern to test the value                                                                                                                                                                      | Takes an `string`                                                                   |
-| `format`               | The [format keyword](https://json-schema.org/understanding-json-schema/reference/string.html#format) allows for basic semantic identification of certain kinds of string values                      |                                                                                     |
-| `required`             | Adds the key to the required items                                                                                                                                                                   | `true` or `false`                                                                   |
-| `deprecated`           | Marks the option as deprecated                                                                                                                                                                       | `true` or `false`                                                                   |
-| `items`                | Contains the schema that describes the possible array items                                                                                                                                          |                                                                                     |
-| `enum`                 | Multiple allowed values                                                                                                                                                                              |                                                                                     |
-| `const`                | Single allowed value                                                                                                                                                                                 |                                                                                     |
-| `examples`             | Some examples you can provide for the end user                                                                                                                                                       | Takes an `array`                                                                    |
-| `minimum`              | Minimum value. Can't be used with `exclusiveMinimum`                                                                                                                                                 | Must be smaller than `maximum` or `exclusiveMaximum` (if used)                      |
-| `exclusiveMinimum`     | Exclusive minimum. Can't be used with `minimum`                                                                                                                                                      | Must be smaller than `maximum` or `exclusiveMaximum` (if used)                      |
-| `maximum`              | Maximum value. Can't be used with `exclusiveMaximum`                                                                                                                                                 | Must be bigger than `minimum` or `exclusiveMinimum` (if used)                       |
-| `exclusiveMaximum`     | Exclusive maximum value. Can't be used with `maximum`                                                                                                                                                | Must be bigger than `minimum` or `exclusiveMinimum` (if used)                       |
-| `multipleOf`           | The yaml-value must be a multiple of. For example: If you set this to 10, allowed values would be 0, 10, 20, 30...                                                                                   | Takes an `int`                                                                      |
-| `additionalProperties` | Allow additional keys in maps. Useful if you want to use for example `additionalAnnotations`, which will be filled with keys that the `jsonschema` can't know                                        | Defaults to `false` if the map is not an empty map. Takes a schema or boolean value |
-| `patternProperties`    | Contains a map which maps schemas to pattern. If properties match the patterns, the given schema is applied                                                                                          | Takes an `object`                                                                   |
-| `anyOf`                | Accepts an array of schemas. None or one must apply                                                                                                                                                  | Takes an `array`                                                                    |
-| `oneOf`                | Accepts an array of schemas. One or more must apply                                                                                                                                                  | Takes an `array`                                                                    |
-| `allOf`                | Accepts an array of schemas. All must apply                                                                                                                                                          | Takes an `array`                                                                    |
-| `if/then/else`         | `if` the given schema applies, `then` also apply the given schema or `else` the other schema                                                                                                         |                                                                                     |
+<!-- prettier-ignore -->
+| Key| Description | Values |
+|-|-|-|
+| [`type`](#type) | Defines the [jsonschema-type](https://json-schema.org/understanding-json-schema/reference/type.html) of the object. Multiple values are supported (e.g. `[string, integer]`) as a shortcut to `anyOf` | `object`, `array`, `string`, `number`, `integer`, `boolean` or `null` |
+| [`title`](#title) | Defines the [title field](https://json-schema.org/understanding-json-schema/reference/generic.html?highlight=title) of the object | Defaults to the key itself |
+| [`description`](#description) | Defines the [description field](https://json-schema.org/understanding-json-schema/reference/generic.html?highlight=description) of the object. | Defaults to the comments just above or below the `@schema` annotations block |
+| [`default`](#default) | Sets the default value and will be displayed first on the users IDE| Takes a `string` |
+| [`properties`](#properties) | Contains a map with keys as property names and values as schema | Takes an `object` |
+| [`pattern`](#pattern) | Regex pattern to test the value | Takes an `string` |
+| [`format`](#format) | The [format keyword](https://json-schema.org/understanding-json-schema/reference/string.html#format) allows for basic semantic identification of certain kinds of string values | Takes a [keyword](https://json-schema.org/understanding-json-schema/reference/string.html#format) |
+| [`required`](#required) | Adds the key to the required items | `true` or `false` |
+| [`deprecated`](#deprecated) | Marks the option as deprecated | `true` or `false` |
+| [`items`](#items) | Contains the schema that describes the possible array items | Takes an `object` |
+| [`enum`](#enum) | Multiple allowed values. Accepts an array of `string` | Takes an `array` |
+| [`const`](#const) | Single allowed value | Takes a `string`|
+| [`examples`](#examples) | Some examples you can provide for the end user | Takes an `array` |
+| [`minimum`](#minimum) | Minimum value. Can't be used with `exclusiveMinimum` | Takes an `integer`. Must be smaller than `maximum` or `exclusiveMaximum` (if used) |
+| [`exclusiveMinimum`](#exclusiveminimum) | Exclusive minimum. Can't be used with `minimum` | Takes an `integer`. Must be smaller than `maximum` or `exclusiveMaximum` (if used) |
+| [`maximum`](#maximum) | Maximum value. Can't be used with `exclusiveMaximum` | Takes an `integer`. Must be bigger than `minimum` or `exclusiveMinimum` (if used) |
+| [`exclusiveMaximum`](#exclusivemaximum) | Exclusive maximum value. Can't be used with `maximum` | Takes an `integer`. Must be bigger than `minimum` or `exclusiveMinimum` (if used) |
+| [`multipleOf`](#multipleof) | The yaml-value must be a multiple of. For example: If you set this to 10, allowed values would be 0, 10, 20, 30... | Takes an `integer` |
+| [`additionalProperties`](#additionalproperties) | Allow additional keys in maps. Useful if you want to use for example `additionalAnnotations`, which will be filled with keys that the `jsonschema` can't know| Defaults to `false` if the map is not an empty map. Takes a schema or boolean value |
+| [`patternProperties`](#patternproperties) | Contains a map which maps schemas to pattern. If properties match the patterns, the given schema is applied| Takes an `object` |
+| [`anyOf`](#anyof) | Accepts an array of schemas. None or one must apply | Takes an `array` |
+| [`oneOf`](#oneof) | Accepts an array of schemas. One or more must apply | Takes an `array` |
+| [`allOf`](#allof) | Accepts an array of schemas. All must apply| Takes an `array` |
+| [`if/then/else`](#ifthenelse) | `if` the given schema applies, `then` also apply the given schema or `else` the other schema| Takes an `object` |
+| `$ref` | Accepts a URL to a valid `jsonschema`. Extend the schema for the current key | Takes an URL |
 
 ## Validation & completion
 
@@ -128,35 +135,430 @@ To take advantage of the generated `values.schema.json`, you can use it within y
 You'll have to place this line at the top of your `values.yaml` (`$schema=<path-or-url-to-your-schema>`) :
 
 ```yaml
-# yaml-language-server: $schema=values.schema.json
-
-foo: bar
-```
-
-## Example
-
-Some schema examples you may want to use:
-
-```yaml
----
 # vim: set ft=yaml:
 # yaml-language-server: $schema=values.schema.json
 
-# This text will be used as description.
 # @schema
-# type: integer
-# minimum: 0
+# required: true
 # @schema
-foo: 1
+# -- This is an example description
+foo: bar
+```
+
+> [!NOTE]
+> You can also point to an online available schema, if you upload a version of yours and want other to be able to implement it.
+>
+> `yaml-language-server: $schema=https://example.org/my-json-schema.json`
+>
+> e.g. from github `https://raw.githubusercontent.com/<user>/<repo>/main/values.schema.json`
+
+### helm-docs
+
+If you're using [`helm-docs`](https://github.com/norwoodj/helm-docs), then you can combine both annotations and use both pre-commit hooks to automatically generate your documentation (e.g. `README.md`) alongside your `values.schema.json`.
+
+If not provided, `title` will be the key and the `description` will be parsed from the `helm-docs` formatted comment.
+
+```yaml
+# @schema
+# type: array
+# @schema
+# -- helm-docs description here
+foo: []
+```
+
+> [!NOTE]
+> Make sure to place the `@schema` annotations **before** the actual key description to avoid having it in your `helm-docs` generated table
+
+## Dependencies
+
+Per default, `helm-schema` will try to also create the schemas for the dependencies in the charts directory. These schemas will be added as properties in the main schema, but the `requiredProperties` field will be nullified. Otherwise you would have to always overwrite all the
+required fields.
+
+If you don't want to generate `jsonschema` for dependencies, you can use the `-n, --no-dependencies` option.
+
+## Limitations
+
+You can't change the `jsonschema` for dependencies by using `@schema` annotations on dependency config values. For example:
+
+```yaml
+# foo is a dependency chart
+foo:
+  # You can't change the schema here, this has no effect.
+  # @schema
+  # type: number
+  # @schema
+  bar: 1
+```
+
+## Examples
+
+Some annotation examples you may want to use, to help you get started!
+
+> [!NOTE]
+> See how the schema behaves with live examples : [values.yaml](./examples/values.yaml)
+
+#### `type`
+
+If `type` isn't specified, current value type will be used.
+
+```yaml
+# Will be parsed as 'string'
+# @schema
+# title: Some title
+# description: Some description
+# @schema
+name: foo
+
+# Will be parsed as 'boolean'
+# @schema
+# type: boolean
+# @schema
+enabled: true
 
 # You can define multiple types as an array.
 # @schema
 # type: [string, integer]
 # minimum: 0
 # @schema
-fool: 1
+cpu: 1
+```
 
-# Same as above but more verbose.
+#### `title`
+
+By default, the `title` will be parsed from the key name. If the key is `foo`, then `title: foo`.
+
+```yaml
+# Define a custom title for the key
+# @schema
+# title: My custom title for 'foo'
+# @schema
+bar: foo
+```
+
+#### `description`
+
+You can provide the `description` through its property or let it be parsed from your comments. If `description` is provided, the comments will not be parsed as description.
+
+If you're implementing it alongside `helm-docs`, read [this](#helm-docs) to do it correctly.
+
+```yaml
+# This text will be used as description.
+# @schema
+# type: integer
+# minimum: 1
+# @schema
+replica: 1
+
+# @schema
+# type: integer
+# minimum: 1
+# @schema
+# This text will be used as description.
+replica: 1
+
+# @schema
+# type: integer
+# minimum: 1
+# description: This text will be used as description.
+# @schema
+# And not this one
+replica: 1
+```
+
+#### `default`
+
+Help users when using their IDE to quickly retrieve the `default` value, for example through <kbd>CTRL+SPACE</kbd>.
+
+```yaml
+# @schema
+# default: standalone
+# enum: [standalone,cluster]
+# @schema
+architecture: ""
+
+# @schema
+# type: boolean
+# default: true
+# @schema
+enabled: true
+```
+
+#### `properties`
+
+Allows user to define valid keys without defining them yet. Give the user an insight of the possible properties, their types and description.
+
+By default, `title` for the keys defined under `properties` will inherit from the main key (e.g. here `title: env`). You need to provide `title` explicitly if you want to change it.
+
+```yaml
+# @schema
+# properties:
+#   CONFIG_PATH:
+#     title: CONFIG_PATH
+#     type: string
+#     description: The local path to the service configuration file
+#   ADMIN_EMAIL:
+#     title: ADMIN_EMAIL
+#     type: string
+#     format: idn-email
+#   API_URL:
+#     type: string
+#     format: idn-hostname
+#     description: Title will be 'env' as we do not specify it here
+# @schema
+# -- Environment variables. If you want to provide auto-completion to the user
+env: {}
+```
+
+#### `pattern`
+
+Pattern that'll be used to test the value.
+
+```yaml
+# @schema
+# pattern: ^api-key
+# @schema
+# The value have to start with the 'api-key-' prefix
+apiKey: "api-key-xxxxx"
+```
+
+#### `format`
+
+Known formats that the value must match. Formats available at [JSON Schema - Formats](https://json-schema.org/understanding-json-schema/reference/string.html#format).
+
+```yaml
+# @schema
+# format: idn-email
+# @schema
+# Requires a valid email format
+email: foo@example.org
+```
+
+#### `required`
+
+By default every property is a required property, you can disable this with `required: false` for a single key. You can also invert this behaviour with the option `helm-schema -k required`, now every property is an optional one.
+
+```yaml
+# @schema
+# required: false
+# @schema
+altName: foo
+```
+
+#### `deprecated`
+
+Let the user know if the key is deprecated, hence should be avoided.
+
+```yaml
+# @schema
+# deprecated: true
+# @schema
+secret: foo
+```
+
+#### `items`
+
+If you want to specify a schema for possible array values without using a default value. E.g. to define the structure of the hosts definition in an k8s ingress resource.
+
+```yaml
+# @schema
+# type: array
+# items:
+#   type: object
+#   properties:
+#     host:
+#       type: object
+#       properties:
+#         url:
+#           type: string
+#           format: idn-hostname
+# @schema
+# Will give auto-completion for the below structure
+# hosts:
+#  - name:
+#      url: my.example.org
+hosts: []
+```
+
+#### `enum`
+
+Allows user to define available values for a given key. Validation will fail and error shown if you try to put another value.
+
+```yaml
+# @schema
+# enum:
+# - application
+# - controller
+# - api
+# @schema
+# Only those three values are accepted
+type: application
+
+# @schema
+# type: array
+# items:
+#   enum: [api,frontend,backend,microservice,teamA,teamB,us-west-1,us-west-2]
+# @schema
+# For each array index, only one of those values are accepted
+tags:
+  - "api"
+  - "teamA"
+  - "us-west-2"
+```
+
+#### `const`
+
+Defines a constant value which shouldn't be changed.
+
+```yaml
+# @schema
+# const: maintainer@example.org
+# @schema
+maintainer: maintainer@example.org
+```
+
+#### `examples`
+
+Provides example values to the user when hovering the key in IDE, or by auto-completion mechanism.
+
+```yaml
+# @schema
+# format: ipv4
+# examples: [192.168.0.1]
+# @schema
+clusterIP: ""
+
+# @schema
+# properties:
+#   CONFIG_PATH:
+#     type: string
+#     description: The local path to the service configuration file
+#     examples: [/path/to/config]
+#   ADMIN_EMAIL:
+#     type: string
+#     format: idn-email
+#     examples: [admin@example.org]
+#   API_URL:
+#     type: string
+#     format: idn-hostname
+#     examples: [https://api.example.org]
+# @schema
+# -- Provide auto-completion and examples to the user
+env: {}
+```
+
+#### `minimum`
+
+The value have to be above or equal the given `integer`.
+
+```yaml
+# @schema
+# minimum: 1
+# @schema
+replica: ""
+```
+
+#### `exclusiveMinimum`
+
+The value have to be strictly above the given `integer`.
+
+```yaml
+# @schema
+# exclusiveMinimum: 0
+# @schema
+replica: ""
+```
+
+#### `maximum`
+
+The value have to be below or equal the given `integer`.
+
+```yaml
+# @schema
+# maximum: 10
+# @schema
+replica: ""
+```
+
+#### `exclusiveMaximum`
+
+The value have to be strictly below the given `integer`.
+
+```yaml
+# @schema
+# exclusiveMaximum: 5
+# @schema
+cpu: ""
+```
+
+#### `multipleOf`
+
+The value have to be a multiple of the given `integer`.
+
+```yaml
+# @schema
+# multipleOf: 1024
+# @schema
+storageCapacity: 2048
+```
+
+#### `additionalProperties`
+
+By default, `additionalProperties` is set to `false` unless you use the `-k additionalProperties` option. Useful when you don't know what nested keys you'll have.
+
+```yaml
+# @schema
+# additionalProperties: true
+# @schema
+# You'll be able to add as many keys below `env:` as you want without invalidating the schema
+env:
+  LONG: foo
+  LIST: bar
+  OF: baz
+  VARIABLES: bat
+
+# @schema
+# additionalProperties: true
+# properties:
+#   REQUIRED_VAR:
+#     type: string
+# @schema
+env:
+  REQUIRED_VAR: foo
+  OPTIONAL_VAR: bar
+```
+
+#### `patternProperties`
+
+Mapping schemas to key name patterns. If properties match the patterns, the given schema is applied.
+
+Useful when you work with a long list of keys and want to define a common schema for a group of them, for example.
+
+E.g. `patternProperties."^API_.*"` key defines the pattern whose schema will be applied on any user provided key that match that pattern.
+
+```yaml
+# @schema
+# type: object
+# patternProperties:
+#   "^API_.*":
+#     type: string
+#     pattern: ^api-key
+#   "^EMAIL_.*":
+#     type: string
+#     format: idn-email
+# @schema
+env:
+  API_PROVIDER_ONE: api-key-xxxxx
+  API_PROVIDER_TWO: api-key-xxxxx
+  EMAIL_ADMIN: admin@example.org
+  EMAIL_DEFAULT_USER: user@example.org
+```
+
+#### `anyOf`
+
+Allows user to define multiple schema fo a single key. Key can be `anyOf` the given schemas or none of them.
+
+```yaml
+# Accepts multiple types
 # @schema
 # anyOf:
 #   - type: string
@@ -164,6 +566,13 @@ fool: 1
 # minimum: 0
 # @schema
 foot: 1
+
+# The above can be simplified with `type:`
+# @schema
+# type: [string, integer]
+# minimum: 0
+# @schema
+fool: 1
 
 # A pattern is also possible.
 # In this case null or some string starting with foo.
@@ -173,22 +582,41 @@ foot: 1
 #   - pattern: ^foo
 # @schema
 bar:
+```
 
-# If you don't use `type`, the current value type will be used.
-# @schema
-# title: Some title
-# description: Some description
-# @schema
-baz: foo
+#### `oneOf`
 
-# By default every property is a required property,
-# you can disable this with `required=false`
-# @schema
-# required: false
-# @schema
-bax: foo
+Allows user to define multiple schema fo a single key. Key must match `oneOf` the given schemas.
 
-# You can also use conditional settings with if/then/else
+```yaml
+# @schema
+# oneOf:
+#   - type: integer
+#   - pattern: Gib$
+#   - pattern: gib$
+# @schema
+storage: 30Gib
+```
+
+#### `allOf`
+
+Allows user to define multiple schema fo a single key. Key must match `oneOf` the given schemas.
+
+```yaml
+# @schema
+# allOf:
+#   - type: string
+#     pattern: Gib$
+#   - enum: [5Gib,10Gib,15Gib]
+# @schema
+storage: 10Gib
+```
+
+#### `if/then/else`
+
+Conditional schema settings with `if`/`then`/`else`
+
+```yaml
 # @schema
 # anyOf:
 #   - type: "null"
@@ -200,59 +628,7 @@ bax: foo
 # else:
 #   description: It's a string
 # @schema
-bay:
-
-# If you want to specify a schema for possible array values without using a default value,
-# do it like this:
-# @schema
-# type: array
-# items:
-#   type: object
-#   properties:
-#     foo:
-#       type: integer
-#     bar:
-#       type: string
-# @schema
-bazi: []
-```
-
-### helm-docs
-
-If you're using [`helm-docs`](https://github.com/norwoodj/helm-docs), then you can combine both annotations and use both pre-commit hooks to automatically generate your documentation (e.g. `README.md`) alongside your `values.schema.json`. Here's how:
-
-```yaml
-# @schema
-# type: array
-# @schema
-# -- helm-docs description here
-foo: []
-```
-
-💡 Make sure to place the `@schema` annotations **before** the actual field description to avoid having it in your `helm-docs` generated table
-
-## Dependencies
-
-Per default, `helm-schema` will try to also create the schemas for the dependencies in the charts
-directory. These schemas will be added as properties in the main schema, but the
-`requiredProperties` field will be nullified. Otherwise you would have to always overwrite all the
-required fields.
-
-If you don't want to generate jsonschemas for dependencies, you can use the `-n` option.
-
-## Limitations
-
-You can't change the jsonschema for dependencies by using `@schema` annotations on dependency
-config values. For example:
-
-```yaml
-# foo is a dependency chart
-foo:
-  # You can't change the schema here, this has no effect.
-  # @schema
-  # type: number
-  # @schema
-  bar: 1
+unknown: foo
 ```
 
 ## License

--- a/examples/Chart.yaml
+++ b/examples/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: example
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/examples/values.schema.json
+++ b/examples/values.schema.json
@@ -1,0 +1,155 @@
+{
+  "properties": {
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "title": "global",
+      "type": "object"
+    },
+    "service": {
+      "additionalProperties": true,
+      "properties": {
+        "conf": {
+          "patternProperties": {
+            "^API_.*": {
+              "pattern": "^api-key",
+              "type": "string"
+            },
+            "^EMAIL_.*": {
+              "format": "idn-email",
+              "type": "string"
+            }
+          },
+          "title": "conf",
+          "type": "object",
+          "examples": [
+            "API_PROVIDER_ONE: api-key-x",
+            "EMAIL_ADMIN: admin@example.org"
+          ]
+        },
+        "contact": {
+          "default": "",
+          "format": "idn-email",
+          "title": "contact",
+          "examples": [
+            "name@domain.tld"
+          ]
+        },
+        "enabled": {
+          "default": "true",
+          "description": "Type will be parsed as boolean",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "env": {
+          "properties": {
+            "ADMIN_EMAIL": {
+              "format": "idn-email",
+              "title": "ADMIN_EMAIL",
+              "type": "string",
+              "examples": [
+                "admin@example.org"
+              ]
+            },
+            "API_URL": {
+              "format": "idn-hostname",
+              "title": "API_URL",
+              "type": "string",
+              "examples": [
+                "https://api.example.org"
+              ]
+            },
+            "CONFIG_PATH": {
+              "description": "The local path to the service configuration file",
+              "title": "CONFIG_PATH",
+              "type": "string",
+              "examples": [
+                "/path/to/config"
+              ]
+            }
+          },
+          "description": "Environment variables. If you want to provide auto-completion to the user ",
+          "title": "env"
+        },
+        "hosts": {
+          "items": {
+            "properties": {
+              "host": {
+                "properties": {
+                  "url": {
+                    "format": "idn-hostname",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "description": "Will give auto-completion for the below structure \nhosts: \n - name:\n     url: my.example.org",
+          "title": "hosts",
+          "type": "array"
+        },
+        "maintainer": {
+          "default": "maintainer@example.org",
+          "const": "maintainer@example.org",
+          "title": "maintainer"
+        },
+        "name": {
+          "default": "",
+          "description": "Name of the deployed service. Defined in the schema annotation",
+          "title": "name",
+          "anyOf": [
+            {},
+            {
+              "pattern": "^foo-"
+            }
+          ]
+        },
+        "port": {
+          "default": "80",
+          "minimum": 80,
+          "maximum": 89,
+          "title": "port",
+          "type": "integer"
+        },
+        "storage": {
+          "default": "10",
+          "title": "storage",
+          "allOf": [
+            {
+              "pattern": "Gib$",
+              "type": "string"
+            },
+            {
+              "enum": [
+                "5Gib",
+                "10Gib",
+                "15Gib"
+              ]
+            }
+          ]
+        },
+        "telemetry": {
+          "default": true,
+          "title": "telemetry",
+          "type": "boolean"
+        },
+        "type": {
+          "default": "application",
+          "title": "type",
+          "enum": [
+            "application",
+            "controller",
+            "api"
+          ]
+        }
+      },
+      "title": "service",
+      "required": [
+        "enabled"
+      ]
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/examples/values.yaml
+++ b/examples/values.yaml
@@ -1,0 +1,115 @@
+# vim: set ft=yaml:
+# yaml-language-server: $schema=values.schema.json
+
+# This is an example values.yaml file, it aims to show how to annotate the keys, and it's its only purpose. 
+# The corresponding values.schema.json has been generated with the below command.
+# helm-schema -n -k additionalProperties
+
+# @schema
+# additionalProperties: true
+# @schema
+service:
+  
+  # Type will be parsed as boolean
+  enabled: true
+
+  # @schema
+  # type: integer
+  # minimum: 80
+  # maximum: 89
+  # @schema
+  port: 80
+
+  # @schema
+  # description: Name of the deployed service. Defined in the schema annotation
+  # anyOf:
+  #   - type: null
+  #   - pattern: ^foo-
+  # @schema
+  # This comment will not be parsed as 'description', the 'description' field take precedence over comments
+  name: 
+    
+  # @schema
+  # properties:
+  #   CONFIG_PATH:
+  #     title: CONFIG_PATH
+  #     type: string
+  #     description: The local path to the service configuration file
+  #     examples: [/path/to/config]
+  #   ADMIN_EMAIL:
+  #     title: ADMIN_EMAIL
+  #     type: string
+  #     format: idn-email
+  #     examples: [admin@example.org]
+  #   API_URL:
+  #     title: API_URL
+  #     type: string
+  #     format: idn-hostname
+  #     examples: [https://api.example.org]
+  # @schema
+  # -- Environment variables. If you want to provide auto-completion to the user 
+  env: {}
+
+  # @schema
+  # type: object
+  # patternProperties:
+  #   "^API_.*":
+  #     type: string
+  #     pattern: ^api-key
+  #   "^EMAIL_.*":
+  #     type: string
+  #     format: idn-email
+  # examples: ["API_PROVIDER_ONE: api-key-x","EMAIL_ADMIN: admin@example.org"]
+  # @schema
+  conf: {}
+
+  # @schema
+  # format: idn-email
+  # examples: [name@domain.tld]
+  # @schema
+  contact: ""
+
+  # @schema
+  # type: boolean
+  # default: true
+  # @schema
+  telemetry: true
+
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   properties:
+  #     host:
+  #       type: object
+  #       properties:
+  #         url:
+  #           type: string
+  #           format: idn-hostname
+  # @schema
+  # Will give auto-completion for the below structure 
+  # hosts: 
+  #  - name:
+  #      url: my.example.org
+  hosts: []
+
+  # @schema
+  # enum:
+  # - application
+  # - controller
+  # - api
+  # @schema
+  type: application
+
+  # @schema
+  # const: maintainer@example.org
+  # @schema
+  maintainer: maintainer@example.org
+
+  # @schema
+  # allOf:
+  #   - type: string
+  #     pattern: Gib$
+  #   - enum: [5Gib,10Gib,15Gib]
+  # @schema
+  storage: 10Gib


### PR DESCRIPTION
# Description 📣

To help users to create great schemas, let's help them by providing use-case examples for every annotation. IMO I think we understand often faster and easier when we see how it works.

This PR includes :
- improvements in the README file
  - simplify the annotation table and add link to their respective section
  - add annotation examples
  - add an example `values.yaml` with the required files to be able to reproduce and play with it
  - add args into the pre-commit config file, for users to be aware that they can customize it

Hope it helps ✌🏽 