### PR TITLE
fix(doc): convert upper to lower case in help for consistency + typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ The binary has the following options:
 ```sh
 Flags:
   -c, --chart-search-root string      "directory to search recursively within for charts (default ".")"
-  -x, --dont-strip-helm-docs-prefix   "Disable the removal of the helm-docs prefix (--)"
+  -x, --dont-strip-helm-docs-prefix   "disable the removal of the helm-docs prefix (--)"
   -d, --dry-run                       "don't actually create files just print to stdout passed"
   -h, --help                          "help for helm-schema"
-  -s, --keep-full-comment             "Keep the whole leading comment (default: cut at empty line)"
-  -l, --log-level string              "Level of logs that should printed, one of (panic, fatal, error, warning, info, debug, trace) (default "info")"
+  -s, --keep-full-comment             "keep the whole leading comment (default: cut at empty line)"
+  -l, --log-level string              "level of logs that should printed, one of (panic, fatal, error, warning, info, debug, trace) (default "info")"
   -n, --no-dependencies               "don't analyze dependencies"
   -o, --output-file string            "jsonschema file path relative to each chart directory to which jsonschema will be written (default 'values.schema.json')"
   -f, --value-files strings           "filenames to check for chart values (default [values.yaml])"
   -k, --skip-auto-generation strings  "skip the auto generation for these fields (default [])"
-  -u, --uncomment                     "Consinder yaml which is commented out"
+  -u, --uncomment                     "consider yaml which is commented out"
   -v, --version                       "version for helm-schema"
 ```
 

--- a/cmd/helm-schema/cli.go
+++ b/cmd/helm-schema/cli.go
@@ -43,7 +43,7 @@ func newCommand(run func(cmd *cobra.Command, args []string) error) (*cobra.Comma
 	}
 
 	logLevelUsage := fmt.Sprintf(
-		"Level of logs that should printed, one of (%s)",
+		"level of logs that should printed, one of (%s)",
 		strings.Join(possibleLogLevels(), ", "),
 	)
 	cmd.PersistentFlags().
@@ -51,11 +51,11 @@ func newCommand(run func(cmd *cobra.Command, args []string) error) (*cobra.Comma
 	cmd.PersistentFlags().
 		BoolP("dry-run", "d", false, "don't actually create files just print to stdout passed")
 	cmd.PersistentFlags().
-		BoolP("keep-full-comment", "s", false, "Keep the whole leading comment (default: cut at empty line)")
+		BoolP("keep-full-comment", "s", false, "keep the whole leading comment (default: cut at empty line)")
 	cmd.PersistentFlags().
-		BoolP("uncomment", "u", false, "Consinder yaml which is commented out")
+		BoolP("uncomment", "u", false, "consider yaml which is commented out")
 	cmd.PersistentFlags().
-		BoolP("dont-strip-helm-docs-prefix", "x", false, "Disable the removal of the helm-docs prefix (--)")
+		BoolP("dont-strip-helm-docs-prefix", "x", false, "disable the removal of the helm-docs prefix (--)")
 	cmd.PersistentFlags().
 		BoolP("no-dependencies", "n", false, "don't analyze dependencies")
 	cmd.PersistentFlags().StringP("log-level", "l", "info", logLevelUsage)


### PR DESCRIPTION
# Description

1. Since some of the help descriptions were starting with an uppercase, and some with a lowercase, let's be consistent and start every description with a lowercase (or an uppercase as you like)
2. Your newly added `-u` option had a typo in its description, it have been fixed

Not a lot but may be useful, I've also seen an odd behaviour when working with multiple charts, I will investigate and potentially open another issue/PR :v: 