### PR TITLE
fix: Make it possible to sort charts with same name

### DIFF
--- a/cmd/helm-schema/main.go
+++ b/cmd/helm-schema/main.go
@@ -229,19 +229,19 @@ loop:
 
 	// sort results with topology sort (only if we're checking the dependencies)
 	if !noDeps {
+		// sort results with topology sort
 		results, err = util.TopSort[*Result, string](results, func(i *Result) string {
-			return i.Chart.Name
+			// the chart is identified by its name and version
+			return fmt.Sprintf("%s-%s", i.Chart.Name, i.Chart.Version)
 		},
 			func(d *Result) []string {
 				deps := []string{}
-				if d.Chart.Dependencies != nil {
-					for _, dep := range d.Chart.Dependencies {
-						deps = append(deps, dep.Name)
-					}
+				for _, dep := range d.Chart.Dependencies {
+					// the dependencies must be identified the same way as above
+					deps = append(deps, fmt.Sprintf("%s-%s", dep.Name, dep.Version))
 				}
 				return deps
-			},
-		)
+			})
 		if err != nil {
 			if _, ok := err.(*util.CircularError); !ok {
 				log.Errorf("Error while sorting results: %s", err)
@@ -373,7 +373,7 @@ loop:
 		}
 	}
 	if foundErrors {
-		return errors.New("Some errors were found")
+		return errors.New("some errors were found")
 	}
 	return nil
 }

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -13,10 +13,54 @@ type Dependency struct {
 	Condition string `yaml:"condition"`
 }
 
+// Maintainer describes a Chart maintainer.
+// https://github.com/helm/helm/blob/main/pkg/chart/metadata.go#L26C1-L34C2
+type Maintainer struct {
+	// Name is a user name or organization name
+	Name string `json:"name,omitempty"`
+	// Email is an optional email address to contact the named maintainer
+	Email string `json:"email,omitempty"`
+	// URL is an optional URL to an address for the named maintainer
+	URL string `json:"url,omitempty"`
+}
+
+// https://github.com/helm/helm/blob/main/pkg/chart/metadata.go#L48
 type ChartFile struct {
-	Name         string       `yaml:"name"`
-	Description  string       `yaml:"description"`
-	Dependencies []Dependency `yaml:"dependencies"`
+	// The name of the chart. Required.
+	Name string `yaml:"name,omitempty"`
+	// The URL to a relevant project page, git repo, or contact person
+	Home string `yaml:"home,omitempty"`
+	// Source is the URL to the source code of this chart
+	Sources []string `yaml:"sources,omitempty"`
+	// A SemVer 2 conformant version string of the chart. Required.
+	Version string `yaml:"version,omitempty"`
+	// A one-sentence description of the chart
+	Description string `yaml:"description,omitempty"`
+	// A list of string keywords
+	Keywords []string `yaml:"keywords,omitempty"`
+	// A list of name and URL/email address combinations for the maintainer(s)
+	Maintainers []*Maintainer `yaml:"maintainers,omitempty"`
+	// The URL to an icon file.
+	Icon string `yaml:"icon,omitempty"`
+	// The API Version of this chart. Required.
+	APIVersion string `yaml:"apiVersion,omitempty"`
+	// The condition to check to enable chart
+	Condition string `yaml:"condition,omitempty"`
+	// The tags to check to enable chart
+	Tags string `yaml:"tags,omitempty"`
+	// The version of the application enclosed inside of this chart.
+	AppVersion string `yaml:"appVersion,omitempty"`
+	// Whether or not this chart is deprecated
+	Deprecated bool `yaml:"deprecated,omitempty"`
+	// Annotations are additional mappings uninterpreted by Helm,
+	// made available for inspection by other applications.
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+	// KubeVersion is a SemVer constraint specifying the version of Kubernetes required.
+	KubeVersion string `yaml:"kubeVersion,omitempty"`
+	// Dependencies are a list of dependencies for a chart.
+	Dependencies []*Dependency `yaml:"dependencies,omitempty"`
+	// Specifies the chart type: application or library
+	Type string `yaml:"type,omitempty"`
 }
 
 // ReadChart parses the given yaml into a ChartFile struct


### PR DESCRIPTION
This makes the topsort function easier to read. Added some comments and changed the variable names.
Also, I changed the identification of the charts (during sorting) to chart name + version. This should make it possible to have dependencies with the same name. It's only a problem if the version is also identical...

So this should fix #27 ...kind of