### PR TITLE
Fix: type of array item is missing if it's object

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -618,6 +618,7 @@ func YamlToSchema(
 			}
 			schema.Properties[keyNode.Value] = &keyNodeSchema
 		}
+		FixRequiredProperties(&schema)
 	}
 
 	return schema

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -542,9 +542,6 @@ func YamlToSchema(
 
 			// only validate or default if $ref is not set
 			if keyNodeSchema.Ref == "" {
-				// Because the `required` field isn't valid jsonschema (but just a helper boolean)
-				// we must convert them to valid requiredProperties fields
-				FixRequiredProperties(&keyNodeSchema)
 
 				// Add key to required array of parent
 				if keyNodeSchema.Required || (!skipAutoGeneration.Required && !keyNodeSchema.HasData) {
@@ -611,6 +608,10 @@ func YamlToSchema(
 						}
 					}
 					keyNodeSchema.Items = &seqSchema
+
+					// Because the `required` field isn't valid jsonschema (but just a helper boolean)
+					// we must convert them to valid requiredProperties fields
+					FixRequiredProperties(&keyNodeSchema)
 				}
 			}
 			if schema.Properties == nil {
@@ -618,7 +619,6 @@ func YamlToSchema(
 			}
 			schema.Properties[keyNode.Value] = &keyNodeSchema
 		}
-		FixRequiredProperties(&schema)
 	}
 
 	return schema


### PR DESCRIPTION
As title, type of items in anyOf is missing if it's a object.

After fix:

<img width="699" alt="image" src="https://github.com/dadav/helm-schema/assets/47812250/922d4ebc-8949-44bb-97c2-1fd61234dc09">
