### PR TITLE
 Append line-break to generated JSON schemas.

### DIFF
--- a/cmd/helm-schema/main.go
+++ b/cmd/helm-schema/main.go
@@ -237,9 +237,11 @@ loop:
 			continue
 		}
 
+		jsonStr = append(jsonStr, '\n')
+
 		if dryRun {
 			log.Infof("Printing jsonschema for %s chart (%s)", result.Chart.Name, result.ChartPath)
-			fmt.Printf("%s\n", jsonStr)
+			fmt.Print(jsonStr)
 		} else {
 			chartBasePath := filepath.Dir(result.ChartPath)
 			if err := os.WriteFile(filepath.Join(chartBasePath, outFile), jsonStr, 0644); err != nil {


### PR DESCRIPTION
Hi,

Thank you for really nice tool.

I am using it to generate schema using pre-commit but it seems generated files are conflicting with pre-commit `end-of-line-fixer` hook as line-breaks is not last character and they are added to the schema.

This PR add linebreak after schema was generated in main command. Similar to `--dry-run`

Thanks,
Grzegorz