### PR TITLE
fix(schema-reference): adding empty line after added schema reference

### DIFF
--- a/pkg/schema/worker.go
+++ b/pkg/schema/worker.go
@@ -89,7 +89,7 @@ func Worker(
 		if addSchemaReference {
 			schemaRef := `# yaml-language-server: $schema=values.schema.json`
 			if !strings.Contains(string(content), schemaRef) {
-				err = util.InsertLineToFile(schemaRef, valuesPath)
+				err = util.InsertLineToFile(schemaRef, valuesPath, true)
 				if err != nil {
 					result.Errors = append(result.Errors, err)
 					results <- result

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -32,7 +32,8 @@ func appendAndNLStr(to *[]byte, from string) {
 }
 
 // InsertLinetoFile inserts a line to the beginning of a file
-func InsertLineToFile(line, file string) error {
+// with an optional empty line before other content
+func InsertLineToFile(line, file string, emptyLine bool) error {
 	fileInfo, err := os.Stat(file)
 	if err != nil {
 		return err
@@ -46,6 +47,10 @@ func InsertLineToFile(line, file string) error {
 	eol := "\n"
 	if len(content) >= 2 && content[len(content)-2] == '\r' && content[len(content)-1] == '\n' {
 		eol = "\r\n"
+	}
+
+	if emptyLine {
+		eol = eol + eol
 	}
 
 	newContent := line + eol + string(content)

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -49,11 +49,12 @@ func InsertLineToFile(line, file string, emptyLine bool) error {
 		eol = "\r\n"
 	}
 
+	separator := eol
 	if emptyLine {
-		eol = eol + eol
+		separator = eol + eol
 	}
 
-	newContent := line + eol + string(content)
+	newContent := line + separator + string(content)
 	return os.WriteFile(file, []byte(newContent), perm)
 }
 


### PR DESCRIPTION
For keeping distance from other content.

If the string `# yaml-language-server: $schema=values.schema.json` is found, _helm-schema_ will still not add the schema reference when called with `--add-schema-reference`, avoiding cases where it would be added twice for _values.yaml_ touched by previous _helm-schema_ versions.

If it isn't found, it will get added with an additional empty line:

```yaml
# yaml-language-server: $schema=values.schema.json

# -- Some comment
foo: bar
```

fixes #48