### PR TITLE
fix(schema-reference): put schema reference below document start

### DIFF
--- a/pkg/schema/worker.go
+++ b/pkg/schema/worker.go
@@ -89,7 +89,7 @@ func Worker(
 		if addSchemaReference {
 			schemaRef := `# yaml-language-server: $schema=values.schema.json`
 			if !strings.Contains(string(content), schemaRef) {
-				err = util.InsertLineToFile(schemaRef, valuesPath)
+				err = util.PrefixFirstYamlDocument(schemaRef, valuesPath)
 				if err != nil {
 					result.Errors = append(result.Errors, err)
 					results <- result

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -31,8 +31,8 @@ func appendAndNLStr(to *[]byte, from string) {
 	*to = append(*to, '\n')
 }
 
-// InsertLinetoFile inserts a line to the beginning of a file
-func InsertLineToFile(line, file string) error {
+// PrefixFirstYamlDocument inserts a line to the beginning of the first YAML document in a file having content
+func PrefixFirstYamlDocument(line, file string) error {
 	fileInfo, err := os.Stat(file)
 	if err != nil {
 		return err
@@ -46,6 +46,13 @@ func InsertLineToFile(line, file string) error {
 	eol := "\n"
 	if len(content) >= 2 && content[len(content)-2] == '\r' && content[len(content)-1] == '\n' {
 		eol = "\r\n"
+	}
+
+	// put line directly below YAML document_start if it exists and nothing is preceding it
+	documentStart := "---" + eol
+	if strings.HasPrefix(string(content), documentStart) {
+		content = content[len(documentStart):]
+		line = documentStart + line
 	}
 
 	newContent := line + eol + string(content)


### PR DESCRIPTION
If the YAML file starts with `---`, put the schema reference comment right below it. Will still put it at the top of the file if there is data bafore `---`.

Since `InsertLineToFile` doesn't just insert some line into some file anymore, but is trying to handle YAML semantics, I've renamed it to `PrefixFirstYamlDocument`. Right now, no code depends on generic "prefix file with line" functionality, adding `# yaml-language-server: $schema=values.schema.json` _somewhere_ is currently the only usage of this method.

Instead of

```yaml
# yaml-language-server: $schema=values.schema.json
---
# -- Some comment
foo: bar
```

`helm-schema --add-schema-reference` now will write

```yaml
---
# yaml-language-server: $schema=values.schema.json
# -- Some comment
foo: bar
```

fixes #47