### PR TITLE
fix(schema): also remove helm-docs tags when not dontRemoveHelmDocsPrefix

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -523,6 +523,11 @@ func YamlToSchema(
 				log.Fatalf("Error while parsing comment of key %s: %v", keyNode.Value, err)
 			}
 			if !dontRemoveHelmDocsPrefix {
+				// remove all lines containing helm-docs @tags, like @ignored, or one of those:
+				// https://github.com/norwoodj/helm-docs/blob/v1.14.2/pkg/helm/chart_info.go#L18-L24
+				helmDocsTagsRemover := regexp.MustCompile(`(?ms)(\r\n|\r|\n)?\s*@\w+(\s+--\s)?[^\n\r]*`)
+				description = helmDocsTagsRemover.ReplaceAllString(description, "")
+
 				prefixRemover := regexp.MustCompile(`(?m)^--\s?`)
 				description = prefixRemover.ReplaceAllString(description, "")
 			}


### PR DESCRIPTION
Comments containing special _helm-docs_ metadata (_tags_) previously became part of the value description;
this commit removes those lines starting with `@something`, and optionally continuing with ` -- something else`

Before:
```json
"description": "This should be the only description\n@default -- Description of default setting",
```

After:
```json
"description": "This should be the only description",
```

fixes #45