### PR TITLE
fix(schema): remove left over `#\n` lines from description

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	SchemaPrefix  = "# @schema"
-	CommentPrefix = "# "
+	CommentPrefix = "#"
 )
 
 const (
@@ -435,11 +435,11 @@ func GetSchemaFromComment(comment string) (Schema, string, error) {
 			continue
 		}
 		if insideSchemaBlock {
-			content := strings.TrimPrefix(line, CommentPrefix)
-			rawSchema = append(rawSchema, strings.TrimPrefix(content, CommentPrefix))
+			content := strings.TrimLeft(strings.TrimPrefix(line, CommentPrefix), " ")
+			rawSchema = append(rawSchema, strings.TrimLeft(strings.TrimPrefix(content, CommentPrefix), " "))
 			result.Set()
 		} else {
-			description = append(description, strings.TrimPrefix(line, CommentPrefix))
+			description = append(description, strings.TrimLeft(strings.TrimPrefix(line, CommentPrefix), " "))
 		}
 	}
 


### PR DESCRIPTION
Removing optional space after `#` line prefix
through `strings.TrimLeft`.

Exampleinput:
```yaml
# -- With space
#
# Without space
#
foo: bar
```

Instead of: `"description": "With space\n\nWithout space\n#"`
we get `"description": "With space\n\nWithout space\n"`

fixes #46