### PR TITLE
Fix ref unmarshal into BoolOrArrayOfString

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -55,6 +55,18 @@ func NewBoolOrArrayOfString(arr []string, b bool) BoolOrArrayOfString {
 	}
 }
 
+func (s *BoolOrArrayOfString) UnmarshalJSON(value []byte) error {
+	var multi []string
+	var single bool
+
+	if err := json.Unmarshal(value, &multi); err == nil {
+		s.Strings = multi
+	} else if err := json.Unmarshal(value, &single); err == nil {
+		s.Bool = single
+	}
+	return nil
+}
+
 func (s *BoolOrArrayOfString) MarshalJSON() ([]byte, error) {
 	if s.Strings == nil {
 		return json.Marshal([]string{})

--- a/tests/ref_input.json
+++ b/tests/ref_input.json
@@ -2,5 +2,18 @@
   "foo": {
     "type": "string",
     "description": "from ref"
+  },
+  "bar": {
+    "type": "object",
+    "description": "from different ref",
+    "properties": {
+      "baz": {
+        "type": "string",
+        "description": "from ref"
+      }
+    },
+    "required": [
+      "baz"
+    ]
   }
 }

--- a/tests/test_ref.yaml
+++ b/tests/test_ref.yaml
@@ -4,3 +4,9 @@
 # @schema
 # Not from ref
 foo: bar
+# @schema
+# $ref: ref_input.json#/bar
+# @schema
+# Not from ref
+bar:
+  baz: qux

--- a/tests/test_ref_expected.schema.json
+++ b/tests/test_ref_expected.schema.json
@@ -2,6 +2,22 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
+    "bar": {
+      "additionalProperties": false,
+      "description": "from different ref",
+      "properties": {
+        "baz": {
+          "description": "from ref",
+          "required": [],
+          "type": "string"
+        }
+      },
+      "required": [
+        "baz"
+      ],
+      "title": "bar",
+      "type": "object"
+    },
     "foo": {
       "default": "bar",
       "description": "from ref",


### PR DESCRIPTION
## Problem

If a $ref has an object that declares `required` properties, helm-schema will return the error

```
json: cannot unmarshal array into Go struct field Schema.properties.required of type schema.BoolOrArrayOfString
```

Example of referenced JSON file:

```
{
  "bar": {
    "type": "object",
    "description": "from ref",
    "properties": {
      "baz": {
        "type": "string",
        "description": "from ref"
      }
    },
    "required": [
      "baz"
    ]
  }
}
```

Another option is setting `required` to `false`.  Both cases cause the above error.

## Solution

Implement `UnmarshalJSON` on BoolOrArrayOfString.