### PR TITLE
Feature/support tgz charts

### DIFF
--- a/cmd/helm-schema/main.go
+++ b/cmd/helm-schema/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	subCharts "github.com/dadav/helm-schema/pkg/chart/subCharts"
+	"github.com/dadav/helm-schema/pkg/chart/searching"
 	"github.com/dadav/helm-schema/pkg/schema"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -56,10 +56,10 @@ func exec(cmd *cobra.Command, _ []string) error {
 	errs := make(chan error)
 	done := make(chan struct{})
 
-	tempDir := subCharts.SearchArchivesOpenTemp(chartSearchRoot, errs)
+	tempDir := searching.SearchArchivesOpenTemp(chartSearchRoot, errs)
 	defer os.RemoveAll(tempDir)
 
-	go subCharts.SearchFiles(chartSearchRoot, chartSearchRoot, "Chart.yaml", dependenciesFilterMap, queue, errs)
+	go searching.SearchFiles(chartSearchRoot, chartSearchRoot, "Chart.yaml", dependenciesFilterMap, queue, errs)
 
 	wg := sync.WaitGroup{}
 	go func() {

--- a/cmd/helm-schema/main.go
+++ b/cmd/helm-schema/main.go
@@ -58,6 +58,7 @@ func exec(cmd *cobra.Command, _ []string) error {
 
 	tempDir := subCharts.SearchArchivesOpenTemp(chartSearchRoot, errs)
 	defer os.RemoveAll(tempDir)
+
 	go subCharts.SearchFiles(chartSearchRoot, chartSearchRoot, "Chart.yaml", dependenciesFilterMap, queue, errs)
 
 	wg := sync.WaitGroup{}

--- a/pkg/chart/searching/dependency_charts.go
+++ b/pkg/chart/searching/dependency_charts.go
@@ -1,4 +1,4 @@
-package subCharts
+package searching
 
 import (
 	"archive/tar"

--- a/pkg/chart/subCharts/dependency_charts.go
+++ b/pkg/chart/subCharts/dependency_charts.go
@@ -1,0 +1,145 @@
+package subCharts
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"github.com/dadav/helm-schema/pkg/chart"
+	"gopkg.in/yaml.v3"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func extractTGZ(src, dest string) error {
+	file, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Open gzip reader
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	// Open tar reader
+	tr := tar.NewReader(gzr)
+
+	// Extract files
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// Resolve file path
+		target := filepath.Join(dest, header.Name)
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			// Create directory if not exists
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			// Ensure directory exists
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+
+			// Create file
+			outFile, err := os.Create(target)
+			if err != nil {
+				return err
+			}
+			defer outFile.Close()
+
+			// Copy file content
+			if _, err := io.Copy(outFile, tr); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func SearchFiles(chartSearchRoot, startPath, fileName string, dependenciesFilter map[string]bool, queue chan<- string, errs chan<- error) {
+	defer close(queue)
+	err := filepath.Walk(startPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			errs <- err
+			return nil
+		}
+
+		if !info.IsDir() && info.Name() == fileName {
+			if filepath.Dir(path) == chartSearchRoot {
+				queue <- path
+				return nil
+			}
+
+			if len(dependenciesFilter) > 0 {
+				chartData, err := os.ReadFile(path)
+				if err != nil {
+					errs <- fmt.Errorf("failed to read Chart.yaml at %s: %w", path, err)
+					return nil
+				}
+
+				var chartFile chart.ChartFile
+				if err := yaml.Unmarshal(chartData, &chartFile); err != nil {
+					errs <- fmt.Errorf("failed to parse Chart.yaml at %s: %w", path, err)
+					return nil
+				}
+
+				if dependenciesFilter[chartFile.Name] {
+					queue <- path
+				}
+			} else {
+				queue <- path
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		errs <- err
+	}
+}
+
+func SearchArchivesOpenTemp(startPath string, errs chan<- error) string {
+	tempDir := ""
+	err := filepath.Walk(startPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			errs <- err
+			return nil
+		}
+		if strings.Contains(info.Name(), "tgz") {
+			//unzip archived charts from deps
+			if tempDir == "" {
+				relativeDir := filepath.Dir(path)
+				tempDir, err = os.MkdirTemp(filepath.Join(".", relativeDir), "tmp")
+				if err != nil {
+					errs <- err
+					return nil
+				}
+			}
+			err = extractTGZ(path, tempDir)
+			if err != nil {
+				errs <- err
+				return nil
+			}
+
+		}
+		return nil
+	})
+	if err != nil {
+		errs <- err
+	}
+	return tempDir
+}

--- a/pkg/chart/subCharts/dependency_charts.go
+++ b/pkg/chart/subCharts/dependency_charts.go
@@ -123,7 +123,7 @@ func SearchArchivesOpenTemp(startPath string, errs chan<- error) string {
 			//unzip archived charts from deps
 			if tempDir == "" {
 				relativeDir := filepath.Dir(path)
-				tempDir, err = os.MkdirTemp(filepath.Join(".", relativeDir), "tmp")
+				tempDir, err = os.MkdirTemp(filepath.Join(relativeDir), "tmp")
 				if err != nil {
 					errs <- err
 					return nil


### PR DESCRIPTION
I saw that helm-schema doesn't support automatically opening dependencies that are tgz archived #109 

Since this seems like a pretty major QOL improvement for the tool I decided to add support for it.

My changes:
1. Added pkg/chart/searching/dependency_charts.go that has functions to manage the finding of files under a helm-chart repo
2. Changed the `searchFiles` func location from main.go to pkg/chart/searching/dependency_charts.go

The way I implemented the archive usage is by opening the archives in a temp folder under charts, and defering the deletion of them for the end of the `main` func

marking this as draft until I add tests