### PR TITLE
feat: unique items

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,19 @@ namespace:
   - bar
 ```
 
+#### `uniqueItems`
+
+A schema can ensure that each of the items in an array is unique. Simply set the uniqueItems keyword to true.
+
+```yaml
+# @schema
+# uniqueItems: true
+# @schema
+namespace:
+  - foo
+  - bar
+```
+
 #### `$ref`
 
 The value must be an URI or relative file.

--- a/cmd/helm-schema/version.go
+++ b/cmd/helm-schema/version.go
@@ -1,3 +1,3 @@
 package main
 
-var version string = "0.18.2"
+var version string = "0.19.0"

--- a/cmd/helm-schema/version.go
+++ b/cmd/helm-schema/version.go
@@ -1,3 +1,3 @@
 package main
 
-var version string = "0.18.1"
+var version string = "0.18.2"

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -257,7 +257,7 @@ type Schema struct {
 	MaxLength            *int                   `yaml:"maxLength,omitempty"              json:"maxLength,omitempty"`
 	MinItems             *int                   `yaml:"minItems,omitempty"              json:"minItems,omitempty"`
 	MaxItems             *int                   `yaml:"maxItems,omitempty"              json:"maxItems,omitempty"`
-	UniqueItems          *bool                  `yaml:"uniqueItems,omitempty"          json:"uniqueItems,omitempty"`
+	UniqueItems          bool                   `yaml:"uniqueItems,omitempty"          json:"uniqueItems,omitempty"`
 }
 
 func NewSchema(schemaType string) *Schema {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -257,6 +257,7 @@ type Schema struct {
 	MaxLength            *int                   `yaml:"maxLength,omitempty"              json:"maxLength,omitempty"`
 	MinItems             *int                   `yaml:"minItems,omitempty"              json:"minItems,omitempty"`
 	MaxItems             *int                   `yaml:"maxItems,omitempty"              json:"maxItems,omitempty"`
+	UniqueItems          *bool                  `yaml:"uniqueItems,omitempty"          json:"uniqueItems,omitempty"`
 }
 
 func NewSchema(schemaType string) *Schema {

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -171,6 +171,22 @@ func TestValidate(t *testing.T) {
 # @schema`,
 			expectedValid: false,
 		},
+		{
+			comment: `
+# @schema
+# type: string
+# uniqueItems: true
+# @schema`,
+			expectedValid: true,
+		},
+		{
+			comment: `
+# @schema
+# type: string
+# uniqueItems: false
+# @schema`,
+			expectedValid: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Make possible use of property [uniqueItems](https://json-schema.org/understanding-json-schema/reference/array#uniqueItems) from jsonSchemas

Can ensure that each of the items in an array is unique.

