### PR TITLE
map helm-docs `tpl` type to `string`

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1770,6 +1770,8 @@ func helmDocsTypeToSchemaType(helmDocsType string) (string, error) {
 		return "array", nil
 	case "map":
 		return "object", nil
+	case "tpl":
+		return "string", nil
 	case "string", "object":
 		return helmDocsType, nil
 	}


### PR DESCRIPTION
This PR adds support for helm-docs `tpl` types, and maps them to strings.