### PR TITLE
fix(ref): root level refs to local schema doesn't try to resolve erronous paths anymore

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -1959,8 +1959,12 @@ func decodeNodeValue(node *yaml.Node) (interface{}, error) {
 func handleSchemaRefs(schema *Schema, valuesPath string) error {
 	// Handle main schema $ref
 	if schema.Ref != "" {
-		refParts := strings.Split(schema.Ref, "#")
-		relFilePath, err := util.IsRelativeFile(valuesPath, refParts[0])
+		fileRef, jsonPointer, hasJSONPointer := strings.Cut(schema.Ref, "#")
+		if fileRef == "" {
+			return nil
+		}
+
+		relFilePath, err := util.IsRelativeFile(valuesPath, fileRef)
 		if err != nil {
 			// Not a relative file path, may be handled elsewhere
 			log.Debug(err)
@@ -1979,15 +1983,15 @@ func handleSchemaRefs(schema *Schema, valuesPath string) error {
 			return fmt.Errorf("failed to read referenced schema file %s: %w", relFilePath, err)
 		}
 
-		if len(refParts) > 1 {
+		if hasJSONPointer && jsonPointer != "" {
 			// Found json-pointer
 			var obj interface{}
 			if err := json.Unmarshal(byteValue, &obj); err != nil {
 				return fmt.Errorf("failed to unmarshal JSON from %s: %w", relFilePath, err)
 			}
-			jsonPointerResultRaw, err := jsonpointer.Get(obj, refParts[1])
+			jsonPointerResultRaw, err := jsonpointer.Get(obj, jsonPointer)
 			if err != nil {
-				return fmt.Errorf("failed to resolve JSON pointer %s in %s: %w", refParts[1], relFilePath, err)
+				return fmt.Errorf("failed to resolve JSON pointer %s in %s: %w", jsonPointer, relFilePath, err)
 			}
 			jsonPointerResultMarshaled, err := json.Marshal(jsonPointerResultRaw)
 			if err != nil {

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -994,6 +994,52 @@ message: fixed`,
 	}
 }
 
+func TestYamlToSchemaPreservesDocumentLocalRootRef(t *testing.T) {
+	yamlContent := `# @schema
+# definitions:
+#   toplevel:
+#     description: "Top Level"
+# $ref: "#/definitions/toplevel"
+# @schema
+toplevel:
+`
+
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlContent), &node); err != nil {
+		t.Fatalf("Failed to unmarshal YAML: %v", err)
+	}
+
+	skipConfig := &SkipAutoGenerationConfig{}
+	schema, err := YamlToSchema("/tmp/values.yaml", &node, false, false, false, true, skipConfig, nil)
+	if err != nil {
+		t.Fatalf("YamlToSchema failed: %v", err)
+	}
+
+	property, ok := schema.Properties["toplevel"]
+	if !ok {
+		t.Fatal("Expected schema to contain toplevel property")
+	}
+
+	if property.Ref != "#/definitions/toplevel" {
+		t.Fatalf("Expected ref to be preserved, got %q", property.Ref)
+	}
+
+	schema.HoistDefinitions()
+
+	if schema.Definitions == nil {
+		t.Fatal("Expected root definitions to be preserved")
+	}
+
+	definition, ok := schema.Definitions["toplevel"]
+	if !ok {
+		t.Fatal("Expected toplevel definition to be present")
+	}
+
+	if definition.Description != "Top Level" {
+		t.Fatalf("Expected toplevel definition description %q, got %q", "Top Level", definition.Description)
+	}
+}
+
 func TestGetPropertyAtPath(t *testing.T) {
 	// Create a nested schema structure
 	schema := &Schema{

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -3,9 +3,10 @@ package util
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -164,10 +165,22 @@ func RemoveCommentsFromYaml(reader io.Reader) ([]byte, error) {
 
 // IsRelativeFile checks if the given string is a relative path to a file
 func IsRelativeFile(root, relPath string) (string, error) {
-	if !path.IsAbs(relPath) {
-		foo := path.Join(path.Dir(root), relPath)
-		_, err := os.Stat(foo)
-		return foo, err
+	if relPath == "" {
+		return "", errors.New("path is empty")
 	}
-	return "", errors.New("Is absolute file")
+
+	if !filepath.IsAbs(relPath) {
+		resolvedPath := filepath.Join(filepath.Dir(root), relPath)
+		fileInfo, err := os.Stat(resolvedPath)
+		if err != nil {
+			return resolvedPath, err
+		}
+		if fileInfo.IsDir() {
+			return resolvedPath, fmt.Errorf("path is a directory: %s", resolvedPath)
+		}
+
+		return resolvedPath, nil
+	}
+
+	return "", errors.New("path is absolute")
 }

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -33,5 +35,77 @@ func TestReadFileAndFixNewline(t *testing.T) {
 		if !bytes.Equal(content, test.output) {
 			t.Errorf("Was expecting %s, but got %s", test.output, content)
 		}
+	}
+}
+
+func TestIsRelativeFile(t *testing.T) {
+	tempDir := t.TempDir()
+	rootFile := filepath.Join(tempDir, "values.yaml")
+	relativeFile := filepath.Join(tempDir, "ref.json")
+	relativeDir := filepath.Join(tempDir, "schemas")
+	absFile := filepath.Join(tempDir, "absolute.json")
+
+	if err := os.WriteFile(rootFile, []byte("root"), 0o644); err != nil {
+		t.Fatalf("failed to create root file: %v", err)
+	}
+	if err := os.WriteFile(relativeFile, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create relative file: %v", err)
+	}
+	if err := os.Mkdir(relativeDir, 0o755); err != nil {
+		t.Fatalf("failed to create relative dir: %v", err)
+	}
+	if err := os.WriteFile(absFile, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to create absolute file: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		root         string
+		relPath      string
+		expectedPath string
+		wantErr      bool
+	}{
+		{
+			name:         "existing relative file",
+			root:         rootFile,
+			relPath:      "ref.json",
+			expectedPath: relativeFile,
+		},
+		{
+			name:    "empty path",
+			root:    rootFile,
+			relPath: "",
+			wantErr: true,
+		},
+		{
+			name:         "relative directory",
+			root:         rootFile,
+			relPath:      "schemas",
+			expectedPath: relativeDir,
+			wantErr:      true,
+		},
+		{
+			name:    "absolute path",
+			root:    rootFile,
+			relPath: absFile,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolvedPath, err := IsRelativeFile(tt.root, tt.relPath)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error")
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if resolvedPath != tt.expectedPath {
+				t.Fatalf("expected resolved path %q, got %q", tt.expectedPath, resolvedPath)
+			}
+		})
 	}
 }

--- a/tests/charts/test_ref_properties.yaml
+++ b/tests/charts/test_ref_properties.yaml
@@ -1,0 +1,15 @@
+# @schema
+# definitions:
+#   port:
+#     type: integer
+#     minimum: 1
+#     maximum: 65535
+# properties:
+#   httpPort:
+#     $ref: "#/definitions/port"
+#   httpsPort:
+#     $ref: "#/definitions/port"
+# @schema
+working:
+  httpPort: 80
+  httpsPort: 443

--- a/tests/charts/test_ref_properties_expected.schema.json
+++ b/tests/charts/test_ref_properties_expected.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "port": {
+      "maximum": 65535,
+      "minimum": 1,
+      "type": "integer"
+    }
+  },
+  "properties": {
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "working": {
+      "additionalProperties": false,
+      "properties": {
+        "httpPort": {
+          "$ref": "#/definitions/port",
+          "required": []
+        },
+        "httpsPort": {
+          "$ref": "#/definitions/port",
+          "required": []
+        }
+      },
+      "required": [],
+      "title": "working"
+    }
+  },
+  "required": [],
+  "type": "object"
+}

--- a/tests/charts/test_ref_toplevel.yaml
+++ b/tests/charts/test_ref_toplevel.yaml
@@ -1,0 +1,7 @@
+# @schema
+# definitions:
+#   toplevel:
+#     description: "Top Level"
+# $ref: "#/definitions/toplevel"
+# @schema
+toplevel: 

--- a/tests/charts/test_ref_toplevel_expected.schema.json
+++ b/tests/charts/test_ref_toplevel_expected.schema.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"definitions": {
+		"toplevel": {
+			"description": "Top Level",
+			"required": []
+		}
+	},
+	"properties": {
+		"toplevel": {
+			"$ref": "#/definitions/toplevel",
+			"required": []
+		},
+		"global": {
+			"description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+			"required": [],
+			"title": "global",
+			"type": "object"
+		}
+	},
+	"required": [],
+	"type": "object"
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rc=0
 


### PR DESCRIPTION
Full disclosure:
Thank you for your test coverage, and your CLAUDE.md for making me hand this over to Copilot.

It also motivated me a bit to see that I still had this repo forked - happy to be able to open a Pull Request for this project again!
I think I made my first baby steps with go for helm-schema back around version 0.12.0, a while ago :)

Fixes #210 